### PR TITLE
Customize app for andishe2 server

### DIFF
--- a/android/app/src/debug/res/values/strings.xml
+++ b/android/app/src/debug/res/values/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-    <string name="app_name">[DEBUG] Rocket.Chat Experimental</string>
-    <string name="share_extension_name">[DEBUG] Rocket.Chat Experimental</string>
+    <string name="app_name">[DEBUG] andishe2</string>
+    <string name="share_extension_name">[DEBUG] andishe2</string>
 </resources>

--- a/android/app/src/experimental/res/values/strings.xml
+++ b/android/app/src/experimental/res/values/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-    <string name="app_name">Rocket.Chat Experimental</string>
-    <string name="share_extension_name">Rocket.Chat Experimental</string>
+    <string name="app_name">andishe2</string>
+    <string name="share_extension_name">andishe2</string>
 </resources>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -57,7 +57,7 @@
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="rocketchat" />
+                <data android:scheme="andishe2" />
             </intent-filter>
         </activity>
         <activity

--- a/android/app/src/main/java/chat/rocket/reactnative/MainActivity.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/MainActivity.kt
@@ -16,7 +16,7 @@ class MainActivity : ReactActivity() {
    * Returns the name of the main component registered from JavaScript. This is used to schedule
    * rendering of the component.
    */
-  override fun getMainComponentName(): String = "RocketChatRN"
+  override fun getMainComponentName(): String = "andishe2"
  
   /**
    * Returns the instance of the [ReactActivityDelegate]. We use [DefaultReactActivityDelegate]

--- a/android/app/src/main/java/chat/rocket/reactnative/share/ShareActivity.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/share/ShareActivity.kt
@@ -11,7 +11,7 @@ import java.util.*
 
 class ShareActivity : AppCompatActivity() {
 
-    private val appScheme = "rocketchat"
+    private val appScheme = "andishe2"
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/android/app/src/official/res/values/strings.xml
+++ b/android/app/src/official/res/values/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-    <string name="app_name">Rocket.Chat</string>
-    <string name="share_extension_name">Rocket.Chat</string>
+    <string name="app_name">andishe2</string>
+    <string name="share_extension_name">andishe2</string>
 </resources>

--- a/app.json
+++ b/app.json
@@ -1,3 +1,3 @@
 {
-	"name": "RocketChatRN"
+        "name": "andishe2"
 }

--- a/app/config/appConfig.ts
+++ b/app/config/appConfig.ts
@@ -1,0 +1,3 @@
+export const DEFAULT_SERVER_URL = 'https://edu97.ir';
+export const DESIGNER_INFO = 'طراح فرهاد صناعی - دبستان اندیشه حسینی';
+export const REGISTRATION_DISABLED_MESSAGE = 'عضویت در این برنامه فقط توسط مدیر انجام می‌شود.';

--- a/app/containers/AppVersion.tsx
+++ b/app/containers/AppVersion.tsx
@@ -5,31 +5,39 @@ import sharedStyles from '../views/Styles';
 import { getReadableVersion } from '../lib/methods/helpers';
 import I18n from '../i18n';
 import { useTheme } from '../theme';
+import { DESIGNER_INFO } from '../config/appConfig';
 
 const styles = StyleSheet.create({
 	container: {
 		alignItems: 'center',
 		justifyContent: 'flex-end'
 	},
-	text: {
-		...sharedStyles.textRegular,
-		fontSize: 13
-	},
-	bold: {
-		...sharedStyles.textSemibold
-	}
+        text: {
+                ...sharedStyles.textRegular,
+                fontSize: 13
+        },
+        bold: {
+                ...sharedStyles.textSemibold
+        },
+        designer: {
+                ...sharedStyles.textRegular,
+                fontSize: 12,
+                marginTop: 4,
+                textAlign: 'center'
+        }
 });
 
 const AppVersion = React.memo(() => {
 	const { colors } = useTheme();
 	return (
-		<View style={styles.container}>
-			<Text style={[styles.text, { color: colors.fontSecondaryInfo }]}>
-				{I18n.t('Version_no', { version: '' })}
-				<Text style={styles.bold}>{getReadableVersion}</Text>
-			</Text>
-		</View>
-	);
+                <View style={styles.container}>
+                        <Text style={[styles.text, { color: colors.fontSecondaryInfo }]}>
+                                {I18n.t('Version_no', { version: '' })}
+                                <Text style={styles.bold}>{getReadableVersion}</Text>
+                        </Text>
+                        <Text style={[styles.designer, { color: colors.fontSecondaryInfo }]}>{DESIGNER_INFO}</Text>
+                </View>
+        );
 });
 
 export default AppVersion;

--- a/app/containers/LoginServices/serviceLogin.ts
+++ b/app/containers/LoginServices/serviceLogin.ts
@@ -151,7 +151,7 @@ const getOAuthState = (loginStyle: TLoginStyle = 'popup') => {
 	if (loginStyle === 'redirect') {
 		obj = {
 			...obj,
-			redirectUrl: 'rocketchat://auth'
+			redirectUrl: 'andishe2://auth'
 		};
 	}
 	return Base64.encodeURI(JSON.stringify(obj));

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -61,7 +61,7 @@ interface IState {
 
 const parseDeepLinking = (url: string) => {
 	if (url) {
-		url = url.replace(/rocketchat:\/\/|https:\/\/go.rocket.chat\//, '');
+                url = url.replace(/andishe2:\/\/|https:\/\/go.rocket.chat\//, '');
 		const regex = /^(room|auth|invite|shareextension)\?/;
 		const match = url.match(regex);
 		if (match) {

--- a/app/lib/methods/helpers/ensureSecureProtocol.test.ts
+++ b/app/lib/methods/helpers/ensureSecureProtocol.test.ts
@@ -18,7 +18,7 @@ describe('Add the protocol https at the begin of the URL', () => {
 		expect(ensureSecureProtocol(linkWithDoubleSlashAtBegin)).toBe('https://www.google.com');
 	});
 	it('return the link as original when sent with rocketchat protocol', () => {
-		const linkRocketChat = 'rocketchat://www.google.com';
+		const linkRocketChat = 'andishe2://www.google.com';
 		expect(ensureSecureProtocol(linkRocketChat)).toBe(linkRocketChat);
 	});
 	it('return the link as original when sent with ftp protocol', () => {

--- a/app/sagas/init.js
+++ b/app/sagas/init.js
@@ -3,12 +3,12 @@ import RNBootSplash from 'react-native-bootsplash';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 import { CURRENT_SERVER, TOKEN_KEY } from '../lib/constants/keys';
+import { DEFAULT_SERVER_URL } from '../config/appConfig';
 import UserPreferences from '../lib/methods/userPreferences';
 import { selectServerRequest } from '../actions/server';
 import { setAllPreferences } from '../actions/sortPreferences';
 import { APP } from '../actions/actionsTypes';
 import log from '../lib/methods/helpers/log';
-import database from '../lib/database';
 import { localAuthenticate } from '../lib/methods/helpers/localAuthentication';
 import { appReady, appStart } from '../actions/app';
 import { RootEnum } from '../definitions';
@@ -24,35 +24,20 @@ export const initLocalSettings = function* initLocalSettings() {
 const restore = function* restore() {
 	console.log('RESTORE');
 	try {
-		const server = UserPreferences.getString(CURRENT_SERVER);
-		let userId = UserPreferences.getString(`${TOKEN_KEY}-${server}`);
+                const server = DEFAULT_SERVER_URL;
+                UserPreferences.setString(CURRENT_SERVER, server);
+                const userId = UserPreferences.getString(`${TOKEN_KEY}-${server}`);
 
-		if (!server) {
-			yield put(appStart({ root: RootEnum.ROOT_OUTSIDE }));
-		} else if (!userId) {
-			const serversDB = database.servers;
-			const serversCollection = serversDB.get('servers');
-			const servers = yield serversCollection.query().fetch();
-
-			// Check if there're other logged in servers and picks first one
-			if (servers.length > 0) {
-				for (let i = 0; i < servers.length; i += 1) {
-					const newServer = servers[i].id;
-					userId = UserPreferences.getString(`${TOKEN_KEY}-${newServer}`);
-					if (userId) {
-						return yield put(selectServerRequest(newServer, newServer.version));
-					}
-				}
-			}
-			yield put(appStart({ root: RootEnum.ROOT_OUTSIDE }));
-		} else {
-			yield localAuthenticate(server);
-			const serverRecord = yield getServerById(server);
-			if (!serverRecord) {
-				return;
-			}
-			yield put(selectServerRequest(server, serverRecord.version));
-		}
+                if (!userId) {
+                        yield put(appStart({ root: RootEnum.ROOT_OUTSIDE }));
+                } else {
+                        yield localAuthenticate(server);
+                        const serverRecord = yield getServerById(server);
+                        if (!serverRecord) {
+                                return;
+                        }
+                        yield put(selectServerRequest(server, serverRecord.version));
+                }
 
 		yield put(appReady({}));
 		const pushNotification = yield call(AsyncStorage.getItem, 'pushNotification');

--- a/app/views/NewServerView/index.tsx
+++ b/app/views/NewServerView/index.tsx
@@ -1,200 +1,112 @@
-import React, { useEffect, useState } from 'react';
-import { AccessibilityInfo, BackHandler, Keyboard, Text } from 'react-native';
+import React, { useCallback, useEffect } from 'react';
+import { Text } from 'react-native';
 import { useDispatch } from 'react-redux';
 import { Image } from 'expo-image';
-import { useForm } from 'react-hook-form';
 
 import { inviteLinksClear } from '../../actions/inviteLinks';
 import { selectServerRequest, serverFinishAdd, serverRequest } from '../../actions/server';
 import Button from '../../containers/Button';
 import FormContainer, { FormContainerInner } from '../../containers/FormContainer';
 import * as HeaderButton from '../../containers/Header/components/HeaderButton';
-import { TServerHistoryModel } from '../../definitions';
+import { INewServerViewProps } from './definitions';
 import I18n from '../../i18n';
 import { useTheme } from '../../theme';
-import { isAndroid, isTablet } from '../../lib/methods/helpers';
-import EventEmitter from '../../lib/methods/helpers/events';
-import ServerInput from './components/ServerInput';
-import { getServerById } from '../../lib/database/services/Server';
 import { useAppSelector } from '../../lib/hooks/useAppSelector';
-import useServersHistory from './hooks/useServersHistory';
-import useCertificate from './hooks/useCertificate';
-import CertificatePicker from './components/CertificatePicker';
-import useConnectServer from './hooks/useConnectServer';
-import { INewServerViewProps } from './definitions';
-import completeUrl from './utils/completeUrl';
+import { DEFAULT_SERVER_URL } from '../../config/appConfig';
 import styles from './styles';
+import { getServerById } from '../../lib/database/services/Server';
 
 const NewServerView = ({ navigation }: INewServerViewProps) => {
-	const dispatch = useDispatch();
-	const { colors } = useTheme();
-	const { previousServer, connecting, failureMessage } = useAppSelector(state => ({
-		previousServer: state.server.previousServer,
-		connecting: state.server.connecting,
-		failureMessage: state.server.failureMessage
-	}));
+        const dispatch = useDispatch();
+        const { colors } = useTheme();
+        const { previousServer, connecting, failureMessage } = useAppSelector(state => ({
+                previousServer: state.server.previousServer,
+                connecting: state.server.connecting,
+                failureMessage: state.server.failureMessage
+        }));
 
-	const {
-		control,
-		watch,
-		formState: { errors },
-		setValue,
-		setError,
-		clearErrors
-	} = useForm({ mode: 'onChange', defaultValues: { workspaceUrl: '' } });
+        const connectToDefaultServer = useCallback(() => {
+                dispatch(inviteLinksClear());
+                dispatch(serverRequest(DEFAULT_SERVER_URL));
+        }, [dispatch]);
 
-	const workspaceUrl = watch('workspaceUrl');
-	const [showBottomInfo, setShowBottomInfo] = useState<boolean>(true);
-	const { deleteServerHistory, queryServerHistory, serversHistory } = useServersHistory();
-	const { certificate, chooseCertificate, removeCertificate, autocompleteCertificate } = useCertificate();
-	const { submit } = useConnectServer({ workspaceUrl, certificate, previousServer });
-	const phoneMarginTop = previousServer ? 32 : 84;
-	const marginTop = isTablet ? 0 : phoneMarginTop;
-	const formContainerStyle = previousServer ? { paddingBottom: 100 } : {};
+        const close = useCallback(async () => {
+                dispatch(inviteLinksClear());
+                if (previousServer) {
+                        const serverRecord = await getServerById(previousServer);
+                        if (serverRecord) {
+                                dispatch(selectServerRequest(previousServer, serverRecord.version));
+                        }
+                }
+        }, [dispatch, previousServer]);
 
-	const onChangeText = (text: string) => {
-		setValue('workspaceUrl', text);
-		queryServerHistory(text);
-		clearErrors();
-		autocompleteCertificate(completeUrl(text));
-	};
+        useEffect(() => {
+                navigation.setOptions({
+                        headerShown: Boolean(previousServer),
+                        headerTitle: previousServer ? I18n.t('Add_Server') : undefined,
+                        headerLeft: () =>
+                                previousServer && !connecting ? (
+                                        <HeaderButton.CloseModal navigation={navigation} onPress={close} testID='new-server-view-close' />
+                                ) : null
+                });
+        }, [close, connecting, navigation, previousServer]);
 
-	const onPressServerHistory = (serverHistory: TServerHistoryModel) => {
-		setValue('workspaceUrl', serverHistory.url);
-		autocompleteCertificate(serverHistory.url);
-		submit({ fromServerHistory: true, username: serverHistory?.username, serverUrl: serverHistory?.url });
-	};
+        useEffect(() => {
+                connectToDefaultServer();
 
-	const handleBackPress = () => {
-		if (navigation.isFocused() && previousServer) {
-			close();
-			return true;
-		}
-		return false;
-	};
+                return () => {
+                        if (previousServer) {
+                                dispatch(serverFinishAdd());
+                        }
+                };
+        }, [connectToDefaultServer, dispatch, previousServer]);
 
-	const handleNewServerEvent = (event: { server: string }) => {
-		let { server } = event;
-		if (!server) {
-			return;
-		}
-		setValue('workspaceUrl', server);
-		server = completeUrl(server);
-		dispatch(serverRequest(server));
-	};
+        const retry = () => {
+                connectToDefaultServer();
+        };
 
-	const close = async () => {
-		dispatch(inviteLinksClear());
-		if (previousServer) {
-			const serverRecord = await getServerById(previousServer);
-			if (serverRecord) {
-				dispatch(selectServerRequest(previousServer, serverRecord.version));
-			}
-		}
-	};
-
-	const setHeader = () => {
-		if (previousServer) {
-			return navigation.setOptions({
-				headerTitle: I18n.t('Add_Server'),
-				headerLeft: () =>
-					!connecting ? <HeaderButton.CloseModal navigation={navigation} onPress={close} testID='new-server-view-close' /> : null
-			});
-		}
-		return navigation.setOptions({
-			headerShown: false
-		});
-	};
-
-	useEffect(() => {
-		if (failureMessage && !errors.workspaceUrl) {
-			AccessibilityInfo.announceForAccessibility(failureMessage);
-			setError('workspaceUrl', { message: failureMessage });
-		}
-	}, [failureMessage]);
-
-	useEffect(() => {
-		EventEmitter.addEventListener('NewServer', handleNewServerEvent);
-		const backHandler = BackHandler.addEventListener('hardwareBackPress', handleBackPress);
-
-		let keyboardShowListener: ReturnType<typeof Keyboard.addListener> | null = null;
-		let keyboardHideListener: ReturnType<typeof Keyboard.addListener> | null = null;
-
-		if (isAndroid) {
-			keyboardShowListener = Keyboard.addListener('keyboardDidShow', () => setShowBottomInfo(false));
-			keyboardHideListener = Keyboard.addListener('keyboardDidHide', () => setShowBottomInfo(true));
-		}
-
-		return () => {
-			EventEmitter.removeListener('NewServer', handleNewServerEvent);
-			backHandler.remove();
-
-			if (isAndroid) {
-				keyboardShowListener?.remove();
-				keyboardHideListener?.remove();
-			}
-
-			if (previousServer) {
-				dispatch(serverFinishAdd());
-			}
-		};
-	}, []);
-
-	useEffect(() => {
-		setHeader();
-	}, [connecting, previousServer]);
-
-	return (
-		<FormContainer
-			style={formContainerStyle}
-			showAppVersion={showBottomInfo}
-			testID='new-server-view'
-			keyboardShouldPersistTaps='handled'>
-			<FormContainerInner accessibilityLabel={I18n.t('Add_server')}>
-				<Image
-					style={{
-						...styles.onboardingImage,
-						marginTop
-					}}
-					source={require('../../static/images/logo_with_name.png')}
-					contentFit='contain'
-				/>
-				<Text
-					style={{
-						...styles.title,
-						color: colors.fontTitlesLabels
-					}}>
-					{I18n.t('Add_server')}
-				</Text>
-				<ServerInput
-					error={errors.workspaceUrl?.message}
-					control={control}
-					serversHistory={serversHistory}
-					onChangeText={onChangeText}
-					onSubmit={submit}
-					onDelete={deleteServerHistory}
-					onPressServerHistory={onPressServerHistory}
-				/>
-				<Button
-					title={I18n.t('Connect')}
-					type='primary'
-					onPress={submit}
-					disabled={!workspaceUrl || connecting}
-					loading={connecting}
-					style={styles.connectButton}
-					testID='new-server-view-button'
-				/>
-			</FormContainerInner>
-			<CertificatePicker
-				certificate={certificate}
-				chooseCertificate={() => chooseCertificate(completeUrl(workspaceUrl))}
-				connecting={connecting}
-				handleRemove={() => removeCertificate(completeUrl(workspaceUrl))}
-				previousServer={previousServer}
-				showBottomInfo
-			/>
-		</FormContainer>
-	);
+        return (
+                <FormContainer
+                        style={previousServer ? { paddingBottom: 100 } : {}}
+                        testID='new-server-view'
+                        keyboardShouldPersistTaps='handled'>
+                        <FormContainerInner accessibilityLabel={I18n.t('Add_server')}>
+                                <Image
+                                        style={{
+                                                ...styles.onboardingImage,
+                                                marginTop: previousServer ? 32 : 84
+                                        }}
+                                        source={require('../../static/images/logo_with_name.png')}
+                                        contentFit='contain'
+                                />
+                                <Text
+                                        style={{
+                                                ...styles.title,
+                                                color: colors.fontTitlesLabels,
+                                                textAlign: 'center'
+                                        }}>
+                                        {I18n.t('Connecting')}
+                                </Text>
+                                <Text style={{ ...styles.description, color: colors.fontSecondaryInfo, textAlign: 'center' }}>
+                                        {DEFAULT_SERVER_URL}
+                                </Text>
+                                {failureMessage ? (
+                                        <Text style={{ ...styles.error, color: colors.fontDanger, textAlign: 'center' }}>
+                                                {failureMessage}
+                                        </Text>
+                                ) : null}
+                                <Button
+                                        title={connecting ? I18n.t('Connecting') : I18n.t('Try_again')}
+                                        type='primary'
+                                        onPress={retry}
+                                        disabled={connecting}
+                                        loading={connecting}
+                                        style={styles.connectButton}
+                                        testID='new-server-view-button'
+                                />
+                        </FormContainerInner>
+                </FormContainer>
+        );
 };
 
 export default NewServerView;

--- a/app/views/NewServerView/styles.ts
+++ b/app/views/NewServerView/styles.ts
@@ -3,23 +3,33 @@ import { StyleSheet } from 'react-native';
 import sharedStyles from '../Styles';
 
 const styles = StyleSheet.create({
-	onboardingImage: {
-		alignSelf: 'center',
-		width: 250,
-		height: 50,
-		marginBottom: 32
-	},
-	title: {
-		...sharedStyles.textBold,
-		fontSize: 24,
-		lineHeight: 36,
-		marginBottom: 24
-	},
-	buttonPrompt: {
-		...sharedStyles.textRegular,
-		textAlign: 'center',
-		lineHeight: 20
-	},
+        onboardingImage: {
+                alignSelf: 'center',
+                width: 250,
+                height: 50,
+                marginBottom: 32
+        },
+        title: {
+                ...sharedStyles.textBold,
+                fontSize: 24,
+                lineHeight: 36,
+                marginBottom: 24
+        },
+        description: {
+                ...sharedStyles.textRegular,
+                fontSize: 16,
+                marginBottom: 12
+        },
+        error: {
+                ...sharedStyles.textSemibold,
+                fontSize: 14,
+                marginTop: 12
+        },
+        buttonPrompt: {
+                ...sharedStyles.textRegular,
+                textAlign: 'center',
+                lineHeight: 20
+        },
 	connectButton: {
 		marginTop: 36
 	}

--- a/app/views/RoomMembersView/components/ActionsSection.tsx
+++ b/app/views/RoomMembersView/components/ActionsSection.tsx
@@ -1,111 +1,13 @@
-import { CompositeNavigationProp, useNavigation } from '@react-navigation/native';
-import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import React from 'react';
-import { View } from 'react-native';
-import { useDispatch } from 'react-redux';
 
-import { setLoading } from '../../../actions/selectedUsers';
-import * as List from '../../../containers/List';
 import { TSubscriptionModel } from '../../../definitions';
-import i18n from '../../../i18n';
-import { usePermissions } from '../../../lib/hooks/usePermissions';
-import log, { events, logEvent } from '../../../lib/methods/helpers/log';
-import { addUsersToRoom } from '../../../lib/services/restApi';
-import { MasterDetailInsideStackParamList } from '../../../stacks/MasterDetailStack/types';
-import { ChatsStackParamList } from '../../../stacks/types';
-
-type TNavigation = CompositeNavigationProp<
-	NativeStackNavigationProp<ChatsStackParamList, 'RoomActionsView'>,
-	NativeStackNavigationProp<MasterDetailInsideStackParamList>
->;
 
 interface IActionsSection {
-	rid: TSubscriptionModel['rid'];
-	t: TSubscriptionModel['t'];
-	joined: boolean;
+        rid: TSubscriptionModel['rid'];
+        t: TSubscriptionModel['t'];
+        joined: boolean;
 }
 
-export default function ActionsSection({ rid, t, joined }: IActionsSection): React.ReactElement {
-	const { navigate, pop } = useNavigation<TNavigation>();
-	const dispatch = useDispatch();
-	const [addUserToJoinedRoomPermission, addUserToAnyCRoomPermission, addUserToAnyPRoomPermission, createInviteLinksPermission] =
-		usePermissions(['add-user-to-joined-room', 'add-user-to-any-c-room', 'add-user-to-any-p-room', 'create-invite-links'], rid);
-
-	const canAddUser =
-		(joined && addUserToJoinedRoomPermission) ||
-		(t === 'c' && addUserToAnyCRoomPermission) ||
-		(t === 'p' && addUserToAnyPRoomPermission) ||
-		false;
-
-	const canInviteUser = createInviteLinksPermission;
-
-	const handleOnPress = ({
-		route,
-		params
-	}: {
-		route: keyof ChatsStackParamList;
-		params: ChatsStackParamList[keyof ChatsStackParamList];
-	}) => {
-		// @ts-ignore
-		navigate(route, params);
-		// @ts-ignore
-		logEvent(events[`RM_GO_${route.replace('View', '').toUpperCase()}`]);
-	};
-
-	const addUser = async () => {
-		try {
-			dispatch(setLoading(true));
-			await addUsersToRoom(rid);
-			pop();
-		} catch (e) {
-			log(e);
-		} finally {
-			dispatch(setLoading(false));
-		}
-	};
-
-	return (
-		<View style={{ paddingTop: canAddUser || canInviteUser ? 16 : 0, paddingBottom: canAddUser || canInviteUser ? 16 : 0 }}>
-			{['c', 'p'].includes(t) && canAddUser ? (
-				<>
-					<List.Separator />
-					<List.Item
-						title='Add_users'
-						onPress={() =>
-							handleOnPress({
-								route: 'SelectedUsersView',
-								params: {
-									title: i18n.t('Add_users'),
-									nextAction: addUser,
-									showSkipText: false
-								}
-							})
-						}
-						testID='room-actions-add-user'
-						left={() => <List.Icon name='add' />}
-						showActionIndicator
-					/>
-					<List.Separator />
-				</>
-			) : null}
-
-			{['c', 'p'].includes(t) && canInviteUser ? (
-				<>
-					<List.Item
-						title='Invite_users'
-						onPress={() =>
-							handleOnPress({
-								route: 'InviteUsersView',
-								params: { rid }
-							})
-						}
-						testID='room-actions-invite-user'
-						left={() => <List.Icon name='user-add' />}
-						showActionIndicator
-					/>
-					<List.Separator />
-				</>
-			) : null}
-		</View>
-	);
+export default function ActionsSection({}: IActionsSection): React.ReactElement | null {
+        return null;
 }

--- a/app/views/WorkspaceView/RegisterDisabledComponent.tsx
+++ b/app/views/WorkspaceView/RegisterDisabledComponent.tsx
@@ -4,20 +4,24 @@ import { Text } from 'react-native';
 import { useAppSelector } from '../../lib/hooks/useAppSelector';
 import { useTheme } from '../../theme';
 import styles from './styles';
+import { REGISTRATION_DISABLED_MESSAGE } from '../../config/appConfig';
 
 const RegisterDisabledComponent = () => {
-	const { colors } = useTheme();
+        const { colors } = useTheme();
 
-	const { Accounts_iframe_enabled, registrationText } = useAppSelector(state => ({
-		registrationText: state.settings.Accounts_RegistrationForm_LinkReplacementText as string,
-		Accounts_iframe_enabled: state.settings.Accounts_iframe_enabled as boolean
-	}));
+        const { Accounts_iframe_enabled } = useAppSelector(state => ({
+                Accounts_iframe_enabled: state.settings.Accounts_iframe_enabled as boolean
+        }));
 
-	if (Accounts_iframe_enabled) {
-		return null;
-	}
+        if (Accounts_iframe_enabled) {
+                return null;
+        }
 
-	return <Text style={[styles.registrationText, { color: colors.fontSecondaryInfo }]}>{registrationText}</Text>;
+        return (
+                <Text style={[styles.registrationText, { color: colors.fontSecondaryInfo }]}>
+                        {REGISTRATION_DISABLED_MESSAGE}
+                </Text>
+        );
 };
 
 export default RegisterDisabledComponent;

--- a/app/views/WorkspaceView/index.tsx
+++ b/app/views/WorkspaceView/index.tsx
@@ -23,16 +23,14 @@ type TNavigation = CompositeNavigationProp<
 >;
 
 const useWorkspaceViewSelector = () =>
-	useAppSelector(state => ({
-		server: state.server.server,
-		Site_Name: state.settings.Site_Name as string,
-		Site_Url: state.settings.Site_Url as string,
-		Assets_favicon_512: state.settings.Assets_favicon_512 as IAssetsFavicon512,
-		registrationForm: state.settings.Accounts_RegistrationForm as string,
-		Accounts_iframe_enabled: state.settings.Accounts_iframe_enabled as boolean,
-		showLoginButton: getShowLoginButton(state),
-		inviteLinkToken: state.inviteLinks.token
-	}));
+        useAppSelector(state => ({
+                server: state.server.server,
+                Site_Name: state.settings.Site_Name as string,
+                Site_Url: state.settings.Site_Url as string,
+                Assets_favicon_512: state.settings.Assets_favicon_512 as IAssetsFavicon512,
+                Accounts_iframe_enabled: state.settings.Accounts_iframe_enabled as boolean,
+                showLoginButton: getShowLoginButton(state)
+        }));
 
 const WorkspaceView = () => {
 	const navigation = useNavigation<TNavigation>();
@@ -46,11 +44,9 @@ const WorkspaceView = () => {
 		Assets_favicon_512,
 		Site_Name,
 		Site_Url,
-		inviteLinkToken,
-		registrationForm,
-		server,
-		showLoginButton
-	} = useWorkspaceViewSelector();
+                server,
+                showLoginButton
+        } = useWorkspaceViewSelector();
 
 	useLayoutEffect(() => {
 		navigation.setOptions({
@@ -58,21 +54,12 @@ const WorkspaceView = () => {
 		});
 	}, [navigation, workspaceDomain]);
 
-	const showRegistrationButton = !!(
-		!Accounts_iframe_enabled &&
-		(registrationForm === 'Public' || (registrationForm === 'Secret URL' && inviteLinkToken?.length))
-	);
-
-	const login = () => {
-		if (Accounts_iframe_enabled) {
-			navigation.navigate('AuthenticationWebView', { url: server, authType: 'iframe' });
+        const login = () => {
+                if (Accounts_iframe_enabled) {
+                        navigation.navigate('AuthenticationWebView', { url: server, authType: 'iframe' });
 			return;
 		}
 		navigation.navigate('LoginView', { title: workspaceDomain });
-	};
-
-	const register = () => {
-		navigation.navigate('RegisterView', { title: workspaceDomain });
 	};
 
 	return (
@@ -84,11 +71,7 @@ const WorkspaceView = () => {
 					<Text style={[styles.serverUrl, { color: colors.fontSecondaryInfo }]}>{Site_Url}</Text>
 				</View>
 				{showLoginButton ? <Button title={I18n.t('Login')} type='primary' onPress={login} testID='workspace-view-login' /> : null}
-				{showRegistrationButton ? (
-					<Button title={I18n.t('Create_account')} type='secondary' onPress={register} testID='workspace-view-register' />
-				) : (
-					<RegisterDisabledComponent />
-				)}
+                                <RegisterDisabledComponent />
 			</FormContainerInner>
 		</FormContainer>
 	);

--- a/e2e/tests/assorted/11-deeplinking.spec.ts
+++ b/e2e/tests/assorted/11-deeplinking.spec.ts
@@ -26,7 +26,7 @@ const DEEPLINK_METHODS = { AUTH: 'auth', ROOM: 'room' };
 const amp = '&';
 
 const getDeepLink = (method: string, server: string, params?: string) => {
-	const deeplink = `rocketchat://${method}?host=${server.replace(/^(http:\/\/|https:\/\/)/, '')}${amp}${params}`;
+	const deeplink = `andishe2://${method}?host=${server.replace(/^(http:\/\/|https:\/\/)/, '')}${amp}${params}`;
 	console.log(`Deeplinking to: ${deeplink}`);
 	return deeplink;
 };
@@ -274,7 +274,7 @@ describe('Deep linking', () => {
 			await device.launchApp({
 				permissions: { notifications: 'YES' },
 				newInstance: true,
-				url: `rocketchat://shareextension?text=${message}`
+				url: `andishe2://shareextension?text=${message}`
 			});
 			await waitFor(element(by.id('share-list-view')))
 				.toBeVisible()
@@ -299,7 +299,7 @@ describe('Deep linking', () => {
 			await device.launchApp({
 				permissions: { notifications: 'YES' },
 				newInstance: true,
-				url: `rocketchat://shareextension?text=${message}`
+				url: `andishe2://shareextension?text=${message}`
 			});
 			await waitFor(element(by.id('share-list-view')))
 				.toBeVisible()
@@ -327,7 +327,7 @@ describe('Deep linking', () => {
 			await device.launchApp({
 				permissions: { notifications: 'YES' },
 				delete: true,
-				url: `rocketchat://shareextension?text=whatever`
+				url: `andishe2://shareextension?text=whatever`
 			});
 			await waitFor(element(by.id('new-server-view')))
 				.toBeVisible()

--- a/ios/RocketChatRN/Info.plist
+++ b/ios/RocketChatRN/Info.plist
@@ -16,7 +16,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
-	<string>$(PRODUCT_NAME)</string>
+	<string>andishe2</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -24,7 +24,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>$(PRODUCT_NAME)</string>
+	<string>andishe2</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
@@ -37,10 +37,10 @@
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
 			<key>CFBundleURLName</key>
-			<string>rocketchat</string>
+			<string>andishe2</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>rocketchat</string>
+				<string>andishe2</string>
 			</array>
 		</dict>
 	</array>

--- a/ios/ShareRocketChatRN/ShareRocketChatRN.swift
+++ b/ios/ShareRocketChatRN/ShareRocketChatRN.swift
@@ -10,7 +10,7 @@ import UIKit
 import MobileCoreServices
 
 class ShareRocketChatRN: UIViewController {
-    let appScheme = "rocketchat"
+    let appScheme = "andishe2"
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)


### PR DESCRIPTION
## Summary
- lock the client to https://edu97.ir by auto-selecting the workspace and removing multi-server UI and invite actions
- update branding to "andishe2", including native app names, deep-link schemes, and in-app designer attribution
- disable public registration flows and present custom messaging for the managed deployment

## Testing
- yarn tsc --noEmit
- ./gradlew assembleOfficialRelease *(fails: Android SDK not available in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e4f521faac832eb9d9f44f5c5dadc2