### PR TITLE
feat: localize login and settings for persian deployment

### DIFF
--- a/app/i18n/index.ts
+++ b/app/i18n/index.ts
@@ -19,133 +19,16 @@ interface ILanguage {
 }
 
 export const LANGUAGES: ILanguage[] = [
-	{
-		label: 'English',
-		value: 'en',
-		file: () => require('./locales/en.json')
-	},
-	{
-		label: 'العربية',
-		value: 'ar',
-		file: () => require('./locales/ar.json')
-	},
-	{
-		label: 'বাংলা',
-		value: 'bn',
-		file: () => require('./locales/bn-IN.json')
-	},
-	{
-		label: 'Czech',
-		value: 'cs',
-		file: () => require('./locales/cs.json')
-	},
-	{
-		label: 'Deutsch',
-		value: 'de',
-		file: () => require('./locales/de.json')
-	},
-	{
-		label: 'Español',
-		value: 'es',
-		file: () => require('./locales/es.json')
-	},
-	{
-		label: 'Finnish',
-		value: 'fi',
-		file: () => require('./locales/fi.json')
-	},
-	{
-		label: 'Français',
-		value: 'fr',
-		file: () => require('./locales/fr.json')
-	},
-	{
-		label: 'हिन्दी',
-		value: 'hi',
-		file: () => require('./locales/hi-IN.json')
-	},
-
-	{
-		label: 'Hungarian',
-		value: 'hu',
-		file: () => require('./locales/hu.json')
-	},
-
-	{
-		label: 'Italiano',
-		value: 'it',
-		file: () => require('./locales/it.json')
-	},
-	{
-		label: '日本語',
-		value: 'ja',
-		file: () => require('./locales/ja.json')
-	},
-	{
-		label: 'Nederlands',
-		value: 'nl',
-		file: () => require('./locales/nl.json')
-	},
-	{
-		label: 'Norwegian',
-		value: 'no',
-		file: () => require('./locales/no.json')
-	},
-	{
-		label: 'Norwegian Nynorsk',
-		value: 'nn',
-		file: () => require('./locales/nn.json')
-	},
-	{
-		label: 'Português (BR)',
-		value: 'pt-BR',
-		file: () => require('./locales/pt-BR.json')
-	},
-	{
-		label: 'Português (PT)',
-		value: 'pt-PT',
-		file: () => require('./locales/pt-PT.json')
-	},
-	{
-		label: 'Russian',
-		value: 'ru',
-		file: () => require('./locales/ru.json')
-	},
-	{
-		label: 'Slovenian (Slovenia)',
-		value: 'sl-SI',
-		file: () => require('./locales/sl-SI.json')
-	},
-	{
-		label: 'Swedish',
-		value: 'sv',
-		file: () => require('./locales/sv.json')
-	},
-	{
-		label: 'தமிழ்',
-		value: 'ta',
-		file: () => require('./locales/ta-IN.json')
-	},
-	{
-		label: 'తెలుగు',
-		value: 'te',
-		file: () => require('./locales/te-IN.json')
-	},
-	{
-		label: 'Türkçe',
-		value: 'tr',
-		file: () => require('./locales/tr.json')
-	},
-	{
-		label: '简体中文',
-		value: 'zh-CN',
-		file: () => require('./locales/zh-CN.json')
-	},
-	{
-		label: '繁體中文',
-		value: 'zh-TW',
-		file: () => require('./locales/zh-TW.json')
-	}
+        {
+                label: 'فارسی',
+                value: 'fa',
+                file: () => require('./locales/fa.json')
+        },
+        {
+                label: 'English',
+                value: 'en',
+                file: () => require('./locales/en.json')
+        }
 ];
 
 interface ITranslations {
@@ -180,8 +63,8 @@ export const setLanguage = (l: string) => {
 	moment.locale(toMomentLocale(locale));
 };
 
-i18n.translations = { en: translations.en?.() };
-const defaultLanguage = { languageTag: 'en', isRTL: false };
+i18n.translations = { fa: translations.fa?.(), en: translations.en?.() };
+const defaultLanguage = { languageTag: 'fa', isRTL: true };
 const availableLanguages = Object.keys(translations);
 const { languageTag } = RNLocalize.findBestAvailableLanguage(availableLanguages) || defaultLanguage;
 

--- a/app/i18n/locales/fa.json
+++ b/app/i18n/locales/fa.json
@@ -1,11 +1,11 @@
 {
-  "Settings": "تنظیمات",
-  "Login": "جهت ورود کلیک کنید",
-  "Username_or_email": "کد ملی دانش آموز",
-  "Password": "کد ملی دانش آموز را مجدداً وارد کنید",
-  "Language": "زبان",
   "Default_browser": "تنظیمات مرورگر",
+  "Language": "زبان",
+  "Login": "جهت ورود کلیک کنید",
   "Media_auto_download": "دانلود خودکار رسانه",
+  "Oops": "خطا",
+  "Password": "کد ملی دانش آموز را مجدداً وارد کنید",
   "Security_and_privacy": "تنظیمات امنیتی",
-  "Oops": "خطا"
+  "Settings": "تنظیمات",
+  "Username_or_email": "کد ملی دانش آموز"
 }

--- a/app/i18n/locales/fa.json
+++ b/app/i18n/locales/fa.json
@@ -1,1 +1,11 @@
-{}
+{
+  "Settings": "تنظیمات",
+  "Login": "جهت ورود کلیک کنید",
+  "Username_or_email": "کد ملی دانش آموز",
+  "Password": "کد ملی دانش آموز را مجدداً وارد کنید",
+  "Language": "زبان",
+  "Default_browser": "تنظیمات مرورگر",
+  "Media_auto_download": "دانلود خودکار رسانه",
+  "Security_and_privacy": "تنظیمات امنیتی",
+  "Oops": "خطا"
+}

--- a/app/sagas/selectServer.ts
+++ b/app/sagas/selectServer.ts
@@ -216,7 +216,7 @@ const handleSelectServer = function* handleSelectServer({ server, version, fetch
 
 		// we'll set serverVersion as metadata for bugsnag
 		logServerVersion(serverVersion);
-		yield put(selectServerSuccess({ server, version: serverVersion, name: serverInfo?.name || 'Rocket.Chat' }));
+            yield put(selectServerSuccess({ server, version: serverVersion, name: serverInfo?.name || 'دبستان اندیشه حسینی' }));
 	} catch (e) {
 		yield put(selectServerFailure());
 		log(e);

--- a/app/views/AttachmentView.tsx
+++ b/app/views/AttachmentView.tsx
@@ -174,8 +174,8 @@ const AttachmentView = (): React.ReactElement => {
 
 		setLoading(true);
 		try {
-			if (LOCAL_DOCUMENT_DIRECTORY && url.startsWith(LOCAL_DOCUMENT_DIRECTORY)) {
-				await CameraRoll.save(url, { album: 'Rocket.Chat' });
+                        if (LOCAL_DOCUMENT_DIRECTORY && url.startsWith(LOCAL_DOCUMENT_DIRECTORY)) {
+                                await CameraRoll.save(url, { album: 'دبستان اندیشه حسینی' });
 			} else {
 				const mediaAttachment = formatAttachmentUrl(url, user.id, user.token, baseUrl);
 				let filename = '';
@@ -184,8 +184,8 @@ const AttachmentView = (): React.ReactElement => {
 				} else {
 					filename = getFilename({ title: attachment.title, type: 'video', mimeType: video_type, url });
 				}
-				const file = await fileDownload(mediaAttachment, {}, filename);
-				await CameraRoll.save(file, { album: 'Rocket.Chat' });
+                                const file = await fileDownload(mediaAttachment, {}, filename);
+                                await CameraRoll.save(file, { album: 'دبستان اندیشه حسینی' });
 				FileSystem.deleteAsync(file, { idempotent: true });
 			}
 			EventEmitter.emit(LISTENER, { message: I18n.t('saved_to_gallery') });

--- a/app/views/ForgotPasswordView.tsx
+++ b/app/views/ForgotPasswordView.tsx
@@ -38,11 +38,11 @@ const ForgotPasswordView = (): React.ReactElement => {
 	const { params } = useRoute<RouteProp<OutsideParamList, 'ForgotPasswordView'>>();
 	const { colors } = useTheme();
 
-	useLayoutEffect(() => {
-		navigation.setOptions({
-			title: params?.title ?? 'Rocket.Chat'
-		});
-	}, [navigation, params?.title]);
+        useLayoutEffect(() => {
+                navigation.setOptions({
+                        title: params?.title ?? 'دبستان اندیشه حسینی'
+                });
+        }, [navigation, params?.title]);
 
 	const resetPassword = async ({ email }: ISubmit) => {
 		if (!isValid) {

--- a/app/views/LoginView/UserForm.tsx
+++ b/app/views/LoginView/UserForm.tsx
@@ -9,17 +9,14 @@ import { useForm } from 'react-hook-form';
 
 import { loginRequest } from '../../actions/login';
 import Button from '../../containers/Button';
-import { useWorkspaceDomain } from '../../lib/hooks/useWorkspaceDomain';
 import { ControlledFormTextInput } from '../../containers/TextInput';
 import I18n from '../../i18n';
 import { OutsideParamList } from '../../stacks/types';
 import { useTheme } from '../../theme';
 import sharedStyles from '../Styles';
-import UGCRules from '../../containers/UserGeneratedContentRules';
 import { useAppSelector } from '../../lib/hooks/useAppSelector';
 import styles from './styles';
 import { handleLoginErrors } from './handleLoginErrors';
-import { REGISTRATION_DISABLED_MESSAGE } from '../../config/appConfig';
 
 interface ISubmit {
 	user: string;
@@ -32,10 +29,9 @@ const schema = yup.object().shape({
 });
 
 const UserForm = () => {
-	const { colors } = useTheme();
-	const dispatch = useDispatch();
-	const navigation = useNavigation<NativeStackNavigationProp<OutsideParamList, 'LoginView'>>();
-	const workspaceDomain = useWorkspaceDomain();
+        const { colors } = useTheme();
+        const dispatch = useDispatch();
+        const navigation = useNavigation<NativeStackNavigationProp<OutsideParamList, 'LoginView'>>();
 
 	const {
 		params: { username }
@@ -51,19 +47,17 @@ const UserForm = () => {
 
 	const {
 		Accounts_EmailOrUsernamePlaceholder,
-		Accounts_PasswordPlaceholder,
-		Accounts_PasswordReset,
-		isFetching,
-		error,
-		failure
-	} = useAppSelector(state => ({
-		isFetching: state.login.isFetching,
-		Accounts_EmailOrUsernamePlaceholder: state.settings.Accounts_EmailOrUsernamePlaceholder as string,
-		Accounts_PasswordPlaceholder: state.settings.Accounts_PasswordPlaceholder as string,
-		Accounts_PasswordReset: state.settings.Accounts_PasswordReset as boolean,
-		failure: state.login.failure,
-		error: state.login.error && state.login.error.data
-	}));
+                Accounts_PasswordPlaceholder,
+                isFetching,
+                error,
+                failure
+        } = useAppSelector(state => ({
+                isFetching: state.login.isFetching,
+                Accounts_EmailOrUsernamePlaceholder: state.settings.Accounts_EmailOrUsernamePlaceholder as string,
+                Accounts_PasswordPlaceholder: state.settings.Accounts_PasswordPlaceholder as string,
+                failure: state.login.failure,
+                error: state.login.error && state.login.error.data
+        }));
 	useEffect(() => {
 		if (failure) {
 			if (error?.error === 'error-invalid-email') {
@@ -75,11 +69,7 @@ const UserForm = () => {
 		}
 	}, [error?.error, failure, getValues, navigation]);
 
-	const forgotPassword = () => {
-		navigation.navigate('ForgotPasswordView', { title: workspaceDomain });
-	};
-
-	const submit = ({ password, user }: ISubmit) => {
+        const submit = ({ password, user }: ISubmit) => {
 		if (!isValid) {
 			return;
 		}
@@ -95,10 +85,10 @@ const UserForm = () => {
 					name='user'
 					control={control}
 					label={I18n.t('Username_or_email')}
-					placeholder={Accounts_EmailOrUsernamePlaceholder}
-					keyboardType='email-address'
-					returnKeyType='next'
-					onSubmitEditing={() => setFocus('password')}
+                                        placeholder={Accounts_EmailOrUsernamePlaceholder || I18n.t('Username_or_email')}
+                                        keyboardType='number-pad'
+                                        returnKeyType='next'
+                                        onSubmitEditing={() => setFocus('password')}
 					testID='login-view-email'
 					textContentType='username'
 					autoComplete='username'
@@ -107,11 +97,12 @@ const UserForm = () => {
 					name='password'
 					control={control}
 					label={I18n.t('Password')}
-					placeholder={Accounts_PasswordPlaceholder}
-					returnKeyType='send'
-					secureTextEntry
-					onSubmitEditing={handleSubmit(submit)}
-					testID='login-view-password'
+                                        placeholder={Accounts_PasswordPlaceholder || I18n.t('Password')}
+                                        returnKeyType='send'
+                                        secureTextEntry
+                                        keyboardType='number-pad'
+                                        onSubmitEditing={handleSubmit(submit)}
+                                        testID='login-view-password'
 					textContentType='password'
 					autoComplete='password'
 					importantForAutofill='yes'
@@ -124,21 +115,7 @@ const UserForm = () => {
 					disabled={!isValid}
 				/>
 			</View>
-			<View style={styles.bottomContainer}>
-				{Accounts_PasswordReset && (
-					<View style={styles.bottomContainerGroup}>
-						<Text style={[styles.bottomContainerText, { color: colors.fontSecondaryInfo }]}>{I18n.t('Forgot_password')}</Text>
-						<Button
-							title={I18n.t('Reset_password')}
-							type='secondary'
-							onPress={forgotPassword}
-							testID='login-view-forgot-password'
-						/>
-					</View>
-				)}
-				<Text style={[styles.registerDisabled, { color: colors.fontSecondaryInfo }]}>{REGISTRATION_DISABLED_MESSAGE}</Text>
-				<UGCRules />
-			</View>
+                        
 		</>
 	);
 };

--- a/app/views/LoginView/index.tsx
+++ b/app/views/LoginView/index.tsx
@@ -1,31 +1,26 @@
 import React, { useLayoutEffect } from 'react';
-import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
+import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
 import { useAppSelector } from '../../lib/hooks/useAppSelector';
 import FormContainer, { FormContainerInner } from '../../containers/FormContainer';
-import * as HeaderButton from '../../containers/Header/components/HeaderButton';
 import LoginServices from '../../containers/LoginServices';
 import { OutsideParamList } from '../../stacks/types';
 import UserForm from './UserForm';
 
 const LoginView = () => {
-	const navigation = useNavigation<NativeStackNavigationProp<OutsideParamList, 'LoginView'>>();
+        const navigation = useNavigation<NativeStackNavigationProp<OutsideParamList, 'LoginView'>>();
 
-	const {
-		params: { title }
-	} = useRoute<RouteProp<OutsideParamList, 'LoginView'>>();
+        const { Accounts_ShowFormLogin } = useAppSelector(state => ({
+                Accounts_ShowFormLogin: state.settings.Accounts_ShowFormLogin as boolean
+        }));
 
-	const { Accounts_ShowFormLogin } = useAppSelector(state => ({
-		Accounts_ShowFormLogin: state.settings.Accounts_ShowFormLogin as boolean
-	}));
-
-	useLayoutEffect(() => {
-		navigation.setOptions({
-			title: title ?? 'Rocket.Chat',
-			headerRight: () => <HeaderButton.Legal testID='login-view-more' navigation={navigation} />
-		});
-	}, [navigation, title]);
+        useLayoutEffect(() => {
+                navigation.setOptions({
+                        title: 'دبستان اندیشه حسینی',
+                        headerRight: undefined
+                });
+        }, [navigation]);
 
 	return (
 		<FormContainer testID='login-view'>

--- a/app/views/LoginView/styles.ts
+++ b/app/views/LoginView/styles.ts
@@ -3,33 +3,12 @@ import { StyleSheet } from 'react-native';
 import sharedStyles from '../Styles';
 
 export default StyleSheet.create({
-	registerDisabled: {
-		...sharedStyles.textRegular,
-		...sharedStyles.textAlignCenter,
-		fontSize: 16
-	},
-	title: {
-		...sharedStyles.textBold,
-		fontSize: 22,
-		marginBottom: 24
-	},
-	inputContainer: {
-		marginVertical: 16
-	},
-	credentialsContainer: {
-		gap: 20
-	},
-	bottomContainer: {
-		flexDirection: 'column',
-		gap: 32,
-		marginTop: 32
-	},
-	bottomContainerGroup: {
-		gap: 12
-	},
-	bottomContainerText: {
-		...sharedStyles.textMedium,
-		alignSelf: 'center',
-		fontSize: 14
-	}
+        title: {
+                ...sharedStyles.textBold,
+                fontSize: 22,
+                marginBottom: 24
+        },
+        credentialsContainer: {
+                gap: 20
+        }
 });

--- a/app/views/SendEmailConfirmationView.tsx
+++ b/app/views/SendEmailConfirmationView.tsx
@@ -46,10 +46,10 @@ const SendEmailConfirmationView = () => {
 		setIsFetching(false);
 	};
 
-	useEffect(() => {
-		navigation.setOptions({
-			title: 'Rocket.Chat'
-		});
+        useEffect(() => {
+                navigation.setOptions({
+                        title: 'دبستان اندیشه حسینی'
+                });
 		if (route.params?.user) {
 			validate(route.params.user);
 		}

--- a/app/views/SettingsView/index.tsx
+++ b/app/views/SettingsView/index.tsx
@@ -1,296 +1,81 @@
-import Clipboard from '@react-native-clipboard/clipboard';
-import { useNavigation } from '@react-navigation/native';
 import React, { useLayoutEffect } from 'react';
-import { Linking, Share } from 'react-native';
-import { Image } from 'expo-image';
-import { useDispatch } from 'react-redux';
+import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
-import { appStart } from '../../actions/app';
-import { logout } from '../../actions/login';
-import { selectServerRequest } from '../../actions/server';
 import * as HeaderButton from '../../containers/Header/components/HeaderButton';
-import NewWindowIcon from '../../containers/NewWindowIcon';
 import * as List from '../../containers/List';
 import SafeAreaView from '../../containers/SafeAreaView';
-import { LISTENER } from '../../containers/Toast';
-import { RootEnum } from '../../definitions';
 import I18n from '../../i18n';
-import { APP_STORE_LINK, LICENSE_LINK, PLAY_MARKET_LINK } from '../../lib/constants/links';
 import { useAppSelector } from '../../lib/hooks/useAppSelector';
-import { clearCache } from '../../lib/methods/clearCache';
-import { deleteMediaFiles } from '../../lib/methods/handleMediaDownload';
-import { getDeviceModel, getReadableVersion, isAndroid } from '../../lib/methods/helpers';
-import EventEmitter from '../../lib/methods/helpers/events';
-import { showConfirmationAlert, showErrorAlert } from '../../lib/methods/helpers/info';
 import { events, logEvent } from '../../lib/methods/helpers/log';
-import openLink from '../../lib/methods/helpers/openLink';
-import { onReviewPress } from '../../lib/methods/helpers/review';
 import { SettingsStackParamList } from '../../stacks/types';
-import { useTheme } from '../../theme';
-import { disconnect } from '../../lib/services/connect';
-import SidebarView from '../SidebarView';
-
-type TLogScreenName = 'SE_GO_LANGUAGE' | 'SE_GO_DEFAULTBROWSER' | 'SE_GO_THEME' | 'SE_GO_PROFILE' | 'SE_GO_SECURITYPRIVACY';
 
 const SettingsView = (): React.ReactElement => {
-	const { colors, theme } = useTheme();
-	const navigation = useNavigation<NativeStackNavigationProp<SettingsStackParamList, 'SettingsView'>>();
-	const dispatch = useDispatch();
-	const isMasterDetail = useAppSelector(state => state.app.isMasterDetail);
-	const { server, version } = useAppSelector(state => state.server);
+        const navigation = useNavigation<NativeStackNavigationProp<SettingsStackParamList, 'SettingsView'>>();
+        const isMasterDetail = useAppSelector(state => state.app.isMasterDetail);
 
-	useLayoutEffect(() => {
-		navigation.setOptions({
-			headerLeft: () =>
-				isMasterDetail ? (
-					<HeaderButton.CloseModal navigation={navigation} testID='settings-view-close' />
-				) : (
-					<HeaderButton.Drawer navigation={navigation} testID='settings-view-drawer' />
-				),
-			title: I18n.t('Settings')
-		});
-	}, [navigation, isMasterDetail]);
+        useLayoutEffect(() => {
+                navigation.setOptions({
+                        headerLeft: () =>
+                                isMasterDetail ? (
+                                        <HeaderButton.CloseModal navigation={navigation} testID='settings-view-close' />
+                                ) : (
+                                        <HeaderButton.Drawer navigation={navigation} testID='settings-view-drawer' />
+                                ),
+                        title: I18n.t('Settings')
+                });
+        }, [navigation, isMasterDetail]);
 
-	const handleLogout = () => {
-		logEvent(events.SE_LOG_OUT);
-		showConfirmationAlert({
-			message: I18n.t('You_will_be_logged_out_of_this_application'),
-			confirmationText: I18n.t('Logout'),
-			onPress: () => dispatch(logout())
-		});
-	};
+        const navigateToScreen = (screen: keyof SettingsStackParamList) => {
+                const screenName = `SE_GO_${screen.replace('View', '').toUpperCase()}` as keyof typeof events;
+                const eventName = events[screenName];
+                if (eventName) {
+                        logEvent(eventName);
+                }
+                navigation.navigate(screen);
+        };
 
-	const handleClearCache = () => {
-		logEvent(events.SE_CLEAR_LOCAL_SERVER_CACHE);
-		showConfirmationAlert({
-			message: I18n.t('This_will_clear_all_your_offline_data'),
-			confirmationText: I18n.t('Clear'),
-			onPress: async () => {
-				dispatch(appStart({ root: RootEnum.ROOT_LOADING, text: I18n.t('Clear_cache_loading') }));
-				await deleteMediaFiles(server);
-				await clearCache({ server });
-				await Image.clearMemoryCache();
-				await Image.clearDiskCache();
-				disconnect();
-				dispatch(selectServerRequest(server, version, true));
-			}
-		});
-	};
-
-	const navigateToScreen = (screen: keyof SettingsStackParamList) => {
-		const screenName = screen.replace('View', '').toUpperCase();
-		logEvent(events[`SE_GO_${screenName}` as TLogScreenName]);
-		navigation.navigate(screen);
-	};
-
-	const sendEmail = async () => {
-		logEvent(events.SE_CONTACT_US);
-		const subject = encodeURI('Rocket.Chat Mobile App Support');
-		const email = encodeURI('support@rocket.chat');
-		const description = encodeURI(`
-			version: ${getReadableVersion}
-			device: ${getDeviceModel}
-		`);
-		try {
-			await Linking.openURL(`mailto:${email}?subject=${subject}&body=${description}`);
-		} catch (e) {
-			logEvent(events.SE_CONTACT_US_F);
-			showErrorAlert(I18n.t('error-email-send-failed', { message: 'support@rocket.chat' }));
-		}
-	};
-
-	const shareApp = () => {
-		let message;
-		if (isAndroid) {
-			message = PLAY_MARKET_LINK;
-		} else {
-			message = APP_STORE_LINK;
-		}
-		Share.share({ message });
-	};
-
-	const saveToClipboard = async (content: string) => {
-		await Clipboard.setString(content);
-		EventEmitter.emit(LISTENER, { message: I18n.t('Copied_to_clipboard') });
-	};
-
-	const copyServerVersion = () => {
-		const vers = version as string;
-		logEvent(events.SE_COPY_SERVER_VERSION, { serverVersion: vers });
-		saveToClipboard(vers);
-	};
-
-	const copyAppVersion = () => {
-		logEvent(events.SE_COPY_APP_VERSION, { appVersion: getReadableVersion });
-		saveToClipboard(getReadableVersion);
-	};
-
-	const onPressLicense = () => {
-		logEvent(events.SE_READ_LICENSE);
-		openLink(LICENSE_LINK, theme);
-	};
-
-	return (
-		<SafeAreaView testID='settings-view'>
-			<List.Container>
-				{isMasterDetail ? (
-					<>
-						<List.Section>
-							<SidebarView navigation={navigation as any} />
-						</List.Section>
-						<List.Section>
-							<List.Separator />
-							<List.Item
-								title='Accessibility_and_Appearance'
-								onPress={() => navigateToScreen('AccessibilityAndAppearanceView')}
-								showActionIndicator
-								left={() => <List.Icon name='accessibility' />}
-							/>
-							<List.Separator />
-							<List.Item
-								title='Profile'
-								onPress={() => navigateToScreen('ProfileView')}
-								showActionIndicator
-								testID='settings-profile'
-								left={() => <List.Icon name='user' />}
-							/>
-							<List.Separator />
-						</List.Section>
-					</>
-				) : null}
-
-				<List.Section>
-					<List.Separator />
-					<List.Item
-						title='Language'
-						onPress={() => navigateToScreen('LanguageView')}
-						showActionIndicator
-						testID='settings-view-language'
-						left={() => <List.Icon name='language' />}
-					/>
-					<List.Separator />
-					<List.Item
-						title='Default_browser'
-						showActionIndicator
-						onPress={() => navigateToScreen('DefaultBrowserView')}
-						testID='settings-view-default-browser'
-						left={() => <List.Icon name='federation' />}
-					/>
-					<List.Separator />
-					<List.Item
-						title='Media_auto_download'
-						showActionIndicator
-						onPress={() => navigateToScreen('MediaAutoDownloadView')}
-						testID='settings-view-media-auto-download'
-						left={() => <List.Icon name='download' />}
-					/>
-					<List.Separator />
-					<List.Item
-						title='Security_and_privacy'
-						showActionIndicator
-						onPress={() => navigateToScreen('SecurityPrivacyView')}
-						testID='settings-view-security-privacy'
-						left={() => <List.Icon name='locker' />}
-					/>
-					<List.Separator />
-				</List.Section>
-
-				<List.Section>
-					<List.Separator />
-					<List.Item
-						title='Get_help'
-						left={() => <List.Icon name='support' />}
-						showActionIndicator
-						onPress={() => navigateToScreen('GetHelpView')}
-						testID='settings-view-get-help'
-					/>
-					<List.Separator />
-					<List.Item
-						title='Share_this_app'
-						showActionIndicator
-						onPress={shareApp}
-						testID='settings-view-share-app'
-						left={() => <List.Icon name='arrow-forward' />}
-					/>
-					<List.Separator />
-					<List.Item
-						title='Legal'
-						showActionIndicator
-						onPress={() => navigateToScreen('LegalView')}
-						testID='settings-view-legal'
-						left={() => <List.Icon name='book' />}
-					/>
-					<List.Separator />
-					<List.Item
-						title='Contact_us'
-						accessibilityRole='link'
-						onPress={sendEmail}
-						testID='settings-view-contact'
-						left={() => <List.Icon name='mail' />}
-						right={() => <NewWindowIcon />}
-					/>
-					<List.Separator />
-					<List.Item
-						title='Review_this_app'
-						accessibilityRole='link'
-						onPress={onReviewPress}
-						testID='settings-view-review-app'
-						left={() => <List.Icon name='star' />}
-						right={() => <NewWindowIcon />}
-					/>
-					<List.Separator />
-					<List.Item
-						title='License'
-						accessibilityRole='link'
-						onPress={onPressLicense}
-						testID='settings-view-license'
-						left={() => <List.Icon name='file-document' />}
-						right={() => <NewWindowIcon />}
-					/>
-					<List.Separator />
-					<List.Item
-						title={I18n.t('Version_no', { version: getReadableVersion })}
-						onPress={copyAppVersion}
-						testID='settings-view-version'
-						translateTitle={false}
-						left={() => <List.Icon name='mobile' />}
-					/>
-					<List.Separator />
-					<List.Item
-						title={I18n.t('Server_version', { version })}
-						onPress={copyServerVersion}
-						subtitle={`${server.split('//')[1]}`}
-						testID='settings-view-server-version'
-						translateTitle={false}
-						translateSubtitle={false}
-						left={() => <List.Icon name='desktop' />}
-					/>
-					<List.Separator />
-				</List.Section>
-
-				<List.Section>
-					<List.Separator />
-					<List.Item
-						title='Clear_cache'
-						testID='settings-view-clear-cache'
-						onPress={handleClearCache}
-						color={colors.fontDanger}
-						left={() => <List.Icon name='prune' color={colors.fontDanger} />}
-					/>
-					<List.Separator />
-					<List.Item
-						title='Logout'
-						testID='settings-logout'
-						onPress={handleLogout}
-						color={colors.fontDanger}
-						left={() => <List.Icon name='logout' color={colors.fontDanger} />}
-					/>
-					<List.Separator />
-				</List.Section>
-			</List.Container>
-		</SafeAreaView>
-	);
+        return (
+                <SafeAreaView testID='settings-view'>
+                        <List.Container>
+                                <List.Section>
+                                        <List.Separator />
+                                        <List.Item
+                                                title='Language'
+                                                onPress={() => navigateToScreen('LanguageView')}
+                                                showActionIndicator
+                                                testID='settings-view-language'
+                                                left={() => <List.Icon name='language' />}
+                                        />
+                                        <List.Separator />
+                                        <List.Item
+                                                title='Default_browser'
+                                                showActionIndicator
+                                                onPress={() => navigateToScreen('DefaultBrowserView')}
+                                                testID='settings-view-default-browser'
+                                                left={() => <List.Icon name='federation' />}
+                                        />
+                                        <List.Separator />
+                                        <List.Item
+                                                title='Media_auto_download'
+                                                showActionIndicator
+                                                onPress={() => navigateToScreen('MediaAutoDownloadView')}
+                                                testID='settings-view-media-auto-download'
+                                                left={() => <List.Icon name='download' />}
+                                        />
+                                        <List.Separator />
+                                        <List.Item
+                                                title='Security_and_privacy'
+                                                showActionIndicator
+                                                onPress={() => navigateToScreen('SecurityPrivacyView')}
+                                                testID='settings-view-security-privacy'
+                                                left={() => <List.Icon name='locker' />}
+                                        />
+                                        <List.Separator />
+                                </List.Section>
+                        </List.Container>
+                </SafeAreaView>
+        );
 };
 
 export default SettingsView;


### PR DESCRIPTION
## Summary
- set Persian as the bundled locale, update translations, and brand the app as دبستان اندیشه حسینی
- tailor the login experience for national ID entry, remove password reset messaging, and drop the legal footer
- slim the settings screen down to language, browser, media auto download, and security options while removing Rocket.Chat references

## Testing
- yarn lint *(fails: existing lint warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_68e58008d464832eb1536ff9f3de5abe